### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,42 +1,28 @@
-<h2 class="c-project-heading--task">Using CSS</h2>
+## Using CSS
 
 Press the **Run** button to see what the starter page looks like.
 
 ## Step 1
 
-Click on the file tab, and select **style.css**. 
+Click on the file tab, and select **style.css**.
 
-<div class="c-project-output">
-![screenshot](images/style.png)
-</div>
+![The style.css file open in the editor, showing the poster's div style rules.](images/style.png)
 
 ## Step 2
 
 Find the `text-align` property and change the word `left` to `center` or `right`.
 
-<div class="c-project-code">
---- code ---
----
-language: css
-line_numbers: true
-line_number_start: 1
-line_highlights: 2
----
+```css line_numbers="true" line_number_start="1" line_highlights="2"
 div {
   text-align: center;
   overflow: hidden;
   border: 2px solid black;
   width: 300px;
 }
---- /code ---
-</div>
+```
 
 ## Now run your code
 
-Click **Run** button to see the text change.
+Click the **Run** button to see the text change.
 
-<div class="c-project-output">
-
-![ADD](images/step2.png)
-
-</div>
+![The Wanted poster shown centred inside a black-bordered box.](images/step2.png)

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,38 +1,21 @@
-<h2 class="c-project-heading--task">Style the poster</h2>
+## Style the poster
 
 Add more code in the CSS to style the poster.
 
-## Step 1
-
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-You can start typing in a new colour in the CSS and it will autocomplete with all related colours.
-
-<div class="c-project-output">
-![ADD](images/colours.gif)
-</div>
-</div>
-
-## Step 2
+> [!TIP]
+>
+> You can start typing in a new colour in the CSS and it will autocomplete with all related colours.
+>
+> ![The CSS editor showing colour suggestions autocompleting as a value is typed.](images/colours.gif)
 
 Use the code below to change the design:
 
-- Change the size, type, and colour of the `border` 
-- Curve the edge with `border-radius` 
-- Edit the size of the `width` 
-- Choose a differnet `background` colour
+- Change the size, type, and colour of the `border`
+- Curve the edge with `border-radius`
+- Edit the size of the `width`
+- Choose a different `background` colour
 
-
-<div class="c-project-code">
---- code ---
----
-language: css
-line_numbers: true
-line_number_start: 1
-line_highlights: 4-7
----
+```css line_numbers="true" line_number_start="1" line_highlights="4-7"
 div {
   text-align: center;
   overflow: hidden;
@@ -41,15 +24,10 @@ div {
   width: 400px;
   background: yellow;
 }
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Click the **Run** button to see your design changes.
 
-<div class="c-project-output">
-
-![ADD](images/step3.png)
-
-</div>
+![The Wanted poster with a yellow background and a red dotted, rounded border.](images/step3.png)

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,20 +1,10 @@
-<h2 class="c-project-heading--task">Image styling</h2>
+## Image styling
 
 Underneath the CSS for `div`, add another CSS style that will apply to images.
 
-## Step 1
-
 Add this code to set the `width`, and add a `border` and some `padding` around the image.
 
-<div class="c-project-code">
-
---- code ---
----
-language: css
-line_numbers: true
-line_number_start: 1
-line_highlights: 10-14
----
+```css line_numbers="true" line_number_start="1" line_highlights="10-14"
 
 div {
   text-align: center;
@@ -31,18 +21,12 @@ img {
 	padding: 10px;
 }
 
---- /code ---
-
-</div>
+```
 
 ## Now run your code
 
 Press **Run** and check that the image has a black border with some space around it.
 
-<div class="c-project-output">
-
 ![An image of a robot with a black border. There is a gap between the robot image and the border.](images/wanted-img-padding.png)
-
-</div>
 
 

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Headings</h2>
+## Headings
 
 Add another CSS style at the bottom of your file for `h1`, which is a heading.
 
@@ -8,14 +8,7 @@ Add the code and experiment with your heading:
 - Play with the `font-size` to get the look you want
 - You could have `wavy underline` or `dotted underline` instead of `underline`
 
-<div class="c-project-code">
---- code ---
----
-language: css
-line_numbers: true
-line_number_start: 10
-line_highlights: 16-21
----
+```css line_numbers="true" line_number_start="10" line_highlights="16-21"
 img {
 	width: 100px;
   	border: 1px solid black;
@@ -28,15 +21,10 @@ h1 {
 	margin: 10px;
 	text-decoration: underline;
 }
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Click the **Run** button to see the heading changes.
 
-<div class="c-project-output">
-
 ![A large heading reading 'Wanted!' underlined in a large black font on a yellow background.](images/wanted-finished-header.png)
-
-</div>

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,32 +1,25 @@
-<h2 class="c-project-heading--task">Challenge</h2>
+## Challenge
 
 Change your HTML and CSS code so that your poster looks the way you want it.
 
-## Step 1
-
-You could:
-- Change the text on the poster by editing `index.html`.
-- Add a different image from the images tab. Replace the `robot.png` in the `index.html` with the name of the image you want to use.
-
-<div class="c-project-code">
---- code ---
----
-language: html
-line_numbers: true
-line_number_start: 1
-line_highlights: 2
----
-  <div>
-    <h1>Wanted!</h1>
-    <h3>Have you seen this robot?</h3>
-    <img src="robot.png">
-    <p>Description: Height: 30cm, Colour: purple and orange, Arms: 4</p>
-    <p>If you have any information, please contact 6207 332 2310</p>
-  </div>
---- /code ---
-</div>
-
-- Make a different poster for an event - it could be a play, a sporting event, or even a poster advertising your Code Club!
+> [!CHALLENGE]
+>
+> You could:
+>
+> - Change the text on the poster by editing `index.html`.
+> - Add a different image from the images tab. Replace the `robot.png` in the `index.html` with the name of the image you want to use.
+>
+> ```html line_numbers="true" line_number_start="1" line_highlights="2"
+>   <div>
+>     <h1>Wanted!</h1>
+>     <h3>Have you seen this robot?</h3>
+>     <img src="robot.png">
+>     <p>Description: Height: 30cm, Colour: purple and orange, Arms: 4</p>
+>     <p>If you have any information, please contact 6207 332 2310</p>
+>   </div>
+> ```
+>
+> - Make a different poster for an event - it could be a play, a sporting event, or even a poster advertising your Code Club!
 
 ## Now run your code
 


### PR DESCRIPTION
Converts all step files to Raspberry Flavoured Markdown (RPF): task headings → `##`, multi-task steps → `## Step N`, code blocks → fenced blocks with inline attributes, tip → `> [!TIP]`, challenge → `> [!CHALLENGE]`, output wrappers dropped to bare images.

Copy fixes agreed with the team:
- Filled in four placeholder image alt texts (`![ADD]`/`![screenshot]`) with descriptions of the actual images (style.css file, the bordered poster, the colour-autocomplete gif, the yellow/red-dotted poster).
- SPAG: 'differnet' → 'different' (step_2); 'Click **Run** button' → 'Click the **Run** button' (step_1).

No code errors found.

`listed: true` preserved (stays published).